### PR TITLE
Improvement in bounding box intersection gives 15% improvement in run time + minor bug fix

### DIFF
--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -17,7 +17,7 @@ LinearAlgebra.:⋅(x::Vector3, y::Vector3) = x[1]*y[1] + x[2]*y[2] + x[3]*y[3]
 Base.:-(p1::Point3, p2::Point3) = Vector3(p1[1]-p2[1], p1[2]-p2[2], p1[3]-p2[3])
 Base.:+(p1::Point3, p2::Point3) = Vector3(p1[1]+p2[1], p1[2]+p2[2], p1[3]+p2[3])
 LinearAlgebra.:×(x::Vector3, y::Vector3) = Vector3(x[2]*y[3]-x[3]*y[2], -x[1]*y[3]+x[3]*y[1], x[1]*y[2]-x[2]*y[1])
-unitize(v::Vector3) = v/(v⋅v)
+unitize(v::Vector3) = v/sqrt(v⋅v)
 
 #---constants
 #const kTolerance = 1e-9

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -69,37 +69,9 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_d
     distsurf = Inf
     max=Point3{T}(box.fDimensions)
     (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
+    ##I have left the distsurf check in this line even though intersectAABoxRay doesn't return it.
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
 end
-# function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
-#     distsurf = Inf
-#     distance = -Inf
-#     distout = Inf
-#     # invdirection = inv.(direction)
-#     for i in 1:3
-#         d=direction[i]
-#         dinv=inv(d)
-#         temp =copysign(box.fDimensions[i],d)
-#         tout =   temp - point[i]
-#         din  = (-temp - point[i])*dinv
-#         dout = tout*dinv
-#         dsur = copysign(tout, d)
-
-#         distance =din > distance  ? din : distance
-#         # if din > distance 
-#         #     distance = din 
-#         # end
-#         distout= dout < distout ? dout : distout
-#         # if dout < distout
-#         #     distout = dout
-#         # end
-#         distsurf = dsur < distsurf ? dsur : distsurf
-#         # if dsur < distsurf
-#         #     distsurf = dsur
-#         # end 
-#     end
-#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
-# end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat
     minimum(box.fDimensions - abs.(point))

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -69,20 +69,28 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T w
     distsurf = Inf
     distance = -Inf
     distout = Inf
+    # invdirection = inv.(direction)
     for i in 1:3
-        din  = (-copysign(box.fDimensions[i],direction[i]) - point[i])/direction[i]
-        tout =   copysign(box.fDimensions[i],direction[i]) - point[i]
-        dout = tout/direction[i]
-        dsur = copysign(tout, direction[i])
-        if din > distance 
-            distance = din 
-        end
-        if dout < distout
-            distout = dout
-        end
-        if dsur < distsurf
-            distsurf = dsur
-        end 
+        d=direction[i]
+        dinv=inv(d)
+        temp =copysign(box.fDimensions[i],d)
+        tout =   temp - point[i]
+        din  = (-temp - point[i])*dinv
+        dout = tout*dinv
+        dsur = copysign(tout, d)
+
+        distance =din > distance  ? din : distance
+        # if din > distance 
+        #     distance = din 
+        # end
+        distout= dout < distout ? dout : distout
+        # if dout < distout
+        #     distout = dout
+        # end
+        distsurf = dsur < distsurf ? dsur : distsurf
+        # if dsur < distsurf
+        #     distsurf = dsur
+        # end 
     end
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
     #invdir = 1.0 ./ direction

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -65,42 +65,41 @@ function distanceToOut(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T 
     #safety > kTolerance(T)/2 ? -1.0 : distance
 end
 
-function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
+function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_direction::Vector3{T}=inv.(direction))::T where T<:AbstractFloat
     distsurf = Inf
-    distance = -Inf
-    distout = Inf
-    # invdirection = inv.(direction)
-    for i in 1:3
-        d=direction[i]
-        dinv=inv(d)
-        temp =copysign(box.fDimensions[i],d)
-        tout =   temp - point[i]
-        din  = (-temp - point[i])*dinv
-        dout = tout*dinv
-        dsur = copysign(tout, d)
-
-        distance =din > distance  ? din : distance
-        # if din > distance 
-        #     distance = din 
-        # end
-        distout= dout < distout ? dout : distout
-        # if dout < distout
-        #     distout = dout
-        # end
-        distsurf = dsur < distsurf ? dsur : distsurf
-        # if dsur < distsurf
-        #     distsurf = dsur
-        # end 
-    end
+    max=Point3{T}(box.fDimensions)
+    (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
-    #invdir = 1.0 ./ direction
-    #tempIn  = -copysign.(box.fDimensions, direction) - point
-    #tempOut =  copysign.(box.fDimensions, direction) - point
-    #distance = maximum(tempIn * invdir)
-    #distout  = minimum(tempOut * invdir)
-    #distsurf = abs(minimum(copysign.(tempOut, direction)))
-    #(distance >= distout || distout <= kTolerance(T)/2 || distsurf <= kTolerance(T)/2) ? Inf : distance
 end
+# function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
+#     distsurf = Inf
+#     distance = -Inf
+#     distout = Inf
+#     # invdirection = inv.(direction)
+#     for i in 1:3
+#         d=direction[i]
+#         dinv=inv(d)
+#         temp =copysign(box.fDimensions[i],d)
+#         tout =   temp - point[i]
+#         din  = (-temp - point[i])*dinv
+#         dout = tout*dinv
+#         dsur = copysign(tout, d)
+
+#         distance =din > distance  ? din : distance
+#         # if din > distance 
+#         #     distance = din 
+#         # end
+#         distout= dout < distout ? dout : distout
+#         # if dout < distout
+#         #     distout = dout
+#         # end
+#         distsurf = dsur < distsurf ? dsur : distsurf
+#         # if dsur < distsurf
+#         #     distsurf = dsur
+#         # end 
+#     end
+#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
+# end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat
     minimum(box.fDimensions - abs.(point))

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -70,7 +70,7 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_d
     max=Point3{T}(box.fDimensions)
     (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
     ##I have left the distsurf check in this line even though intersectAABoxRay doesn't return it.
-    (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
+    (distance >= distout || isnan(distance) || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
 end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -120,74 +120,14 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector
     (distance,distout)= intersectAABoxRay(bb.min,bb.max,point,dir,rcp_dir)
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end
-# function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-#     point = point - (bb.max + bb.min)/2
-#     dimens = (bb.max - bb.min)/2
-#     distsurf = Inf
-#     distance = -Inf
-#     distout = Inf
-#     for i in 1:3
-#         d=dir[i]
-#         invd=rcp_dir[i]
-#         signeddim = copysign(dimens[i],d) 
-#         din  = (-signeddim - point[i])*invd
-#         tout =   signeddim - point[i]
-#         dout = tout*invd
-#         dsur = copysign(tout, d)
-#         distance =din > distance  ? din : distance
-#         distout= dout < distout ? dout : distout
-#         distsurf = dsur < distsurf ? dsur : distsurf
-#     end
-#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
-# end
 
-
-# function intersectAABBRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-#     tmin=typemin(T)
-#     tmax=typemax(T)
-#     for i in 1:3
-#         invd=rcp_dir[i]
-#         p=point[i]
-#         t1 = (bbmin[i]-p)*invd
-#         t2 = (bbmax[i]-p)*invd
-#         tmin=min(max(t1,tmin),max(t2,tmin))
-#         tmax=max(min(t1,tmax),min(t2,tmax))
-#     end
-#     (tmin,tmax) 
-# end
-
-
-# function intersectAABBRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-
-
-#     t1v=(bbmin-point)*rcp_dir
-#     t2v=(bbmax-point)*rcp_dir
-#     # From here on down all we are doing is calculating the following commented lines
-#     # tmin = maximum(min.(t1v,t2v))
-#     # tmax = minimum(max.(t1v,t2v))
-
-#     t1 = t1v[1]
-#     t2 = t2v[1]
-#     flip = t1 > t2
-#     tmin =ifelse(flip,t2,t1)
-#     tmax =ifelse(flip,t1,t2)
-#     for i in 2:3 
-#         t1 = t1v[i]
-#         t2 = t2v[i]
-#         flip = t1 > t2
-#         t1 =ifelse(flip,t2,t1)
-#         t2 =ifelse(flip,t1,t2)
-#         tmin = ifelse(t1>tmin,t1,tmin)
-#         tmax = ifelse(t2<tmax,t2,tmax)
-#     end
-#     (tmin,tmax)
-# end
 function intersectAABoxRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
 
 
     t1v=(bbmin-point)*rcp_dir
     t2v=(bbmax-point)*rcp_dir
     # From here on down all we are doing is calculating the following commented lines
+    # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
     # tmax = minimum(max.(t1v,t2v))
 

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -118,7 +118,7 @@ function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vect
 
     distsurf = Inf
     (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
-    (distance >= distout || isnan(distance) || distout <= kTolerance(T) / 2 || abs(distsurf) <= kTolerance(T) / 2) ? false : true
+    (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
 end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
@@ -129,7 +129,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
 
     t1v = (bbmin - point) * rcp_dir
     t2v = (bbmax - point) * rcp_dir
-
+    
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
@@ -138,6 +138,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
     min(x, y) = ifelse(x < y, x, y)
     max(x, y) = ifelse(x > y, x, y)
 
+
     for i in 1:3
         t1 = t1v[i]
         t2 = t2v[i]
@@ -145,7 +146,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
         tmin = max(ifelse(flip, t2, t1), tmin)
         tmax = min(ifelse(flip, t1, t2), tmax)
     end
-
+    return (tmin,tmax)
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -121,34 +121,33 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end
 
-function intersectAABoxRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-
-
-    t1v=(bbmin-point)*rcp_dir
-    t2v=(bbmax-point)*rcp_dir
+#---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
+function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+    t1v = (bbmin - point) * rcp_dir
+    t2v = (bbmax - point) * rcp_dir
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
     # tmax = minimum(max.(t1v,t2v))
 
-    min(x,y) = ifelse(x < y , x, y)
-    max(x,y) = ifelse(x > y , x, y)
+    min(x, y) = ifelse(x < y, x, y)
+    max(x, y) = ifelse(x > y, x, y)
 
     t1 = t1v[1]
     t2 = t2v[1]
     flip = t1 > t2
-    tmin =ifelse(flip,t2,t1)
-    tmax =ifelse(flip,t1,t2)
-    for i in 2:3 
+    tmin = ifelse(flip, t2, t1)
+    tmax = ifelse(flip, t1, t2)
+    for i in 2:3
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
-        t1 =ifelse(flip,t2,t1)
-        t2 =ifelse(flip,t1,t2)
-        tmin = max(t1,tmin)
-        tmax = min(t2,tmax)
+        t1 = ifelse(flip, t2, t1)
+        t2 = ifelse(flip, t1, t2)
+        tmin = max(t1, tmin)
+        tmax = min(t2, tmax)
     end
-    (tmin,tmax)
+    (tmin, tmax)
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -123,8 +123,13 @@ end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
 function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+    
+    tmin = typemin(T)
+    tmax = typemax(T)
+
     t1v = (bbmin - point) * rcp_dir
     t2v = (bbmax - point) * rcp_dir
+
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
@@ -133,19 +138,14 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
     min(x, y) = ifelse(x < y, x, y)
     max(x, y) = ifelse(x > y, x, y)
 
-    t1 = t1v[1]
-    t2 = t2v[1]
-    flip = t1 > t2
-    tmin = ifelse(flip, t2, t1)
-    tmax = ifelse(flip, t1, t2)
-    for i in 2:3
+    for i in 1:3
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
         tmin = max(ifelse(flip, t2, t1), tmin)
         tmax = min(ifelse(flip, t1, t2), tmax)
     end
-    (tmin, tmax)
+
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -114,11 +114,11 @@ GeometryBasics.faces(::AABB{T}) where T = QuadFace{Int64}[(1,3,7,2), (1,2,6,4), 
 GeometryBasics.normals(::AABB{T}) where T = Point3{T}[(0,0,-1), (0,-1,0), (-1,0,0), (1,0,0), (0,1,0), (0,0,1)]
 
 inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
-function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-    
+function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+
     distsurf = Inf
-    (distance,distout)= intersectAABoxRay(bb.min,bb.max,point,dir,rcp_dir)
-    (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
+    (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
+    (distance >= distout || isnan(distance) || distout <= kTolerance(T) / 2 || abs(distsurf) <= kTolerance(T) / 2) ? false : true
 end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
@@ -142,10 +142,8 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
-        t1 = ifelse(flip, t2, t1)
-        t2 = ifelse(flip, t1, t2)
-        tmin = max(t1, tmin)
-        tmax = min(t2, tmax)
+        tmin = max(ifelse(flip, t2, t1), tmin)
+        tmax = min(ifelse(flip, t1, t2), tmax)
     end
     (tmin, tmax)
 end

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -121,19 +121,25 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T}) where T
     distance = -Inf
     distout = Inf
     for i in 1:3
-        din  = (-copysign(dimens[i],dir[i]) - point[i])/dir[i]
-        tout =   copysign(dimens[i],dir[i]) - point[i]
-        dout = tout/dir[i]
-        dsur = copysign(tout, dir[i])
-        if din > distance 
-            distance = din 
-        end
-        if dout < distout
-            distout = dout
-        end
-        if dsur < distsurf
-            distsurf = dsur
-        end 
+        d=dir[i]
+        invd=inv(d)
+        signeddim = copysign(dimens[i],dir[i]) 
+        din  = (-signeddim - point[i])*invd
+        tout =   signeddim - point[i]
+        dout = tout*invd
+        dsur = copysign(tout, d)
+        distance =din > distance  ? din : distance
+        distout= dout < distout ? dout : distout
+        distsurf = dsur < distsurf ? dsur : distsurf
+        # if din > distance 
+        #     distance = din 
+        # end
+        # if dout < distout
+        #     distout = dout
+        # end
+        # if dsur < distsurf
+        #     distsurf = dsur
+        # end 
     end
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end


### PR DESCRIPTION
First, the bug fix is to make `unitize` return a vector with a magnitude of 1.

I thought this would just be a micro-optimization but it ends up being fairly significant.

There are two caveats to this improvement:
1. As you will see in the code both the affected methods calculated a term `distsurf`, which I could not really figure out what it consistently calculated so I was unable to implement it.  I don't think that should change the results much.
2. I do get some minor differences in the heatmap from the x-ray, when I take a difference between the two methods.  I honestly don't know what is right.

Running the benchmark:
```julia 
using Revise, Geom4hep
using BenchmarkTools
includet("./XRay.jl")
const full2 = processGDML("examples/cms2018.gdml", Float64)
const volume2 = full2[1,7,1]
const world2 = getWorld(volume2)
const nav2 = BVHNavigator(world2)
@time img= generateXRay(nav2, world2, 1e4, 1)
@time img= generateXRay(nav2, world2, 1e4, 1)
```
Master:
```julia
julia> @time img= generateXRay(nav2, world2, 1e4, 1);
 2.374147 seconds (10 allocations: 80.766 KiB)
```
This PR:
```julia
julia> @time img= generateXRay(nav2, world2, 1e4, 1);
  0.773122 seconds (10 allocations: 80.766 KiB)
```