### PR TITLE
Bug fix in extent calculations (25% regression)  & Bounding Box checks in Booleans+Placed Volume(50% better)

### DIFF
--- a/src/BasicTypes.jl
+++ b/src/BasicTypes.jl
@@ -17,7 +17,7 @@ LinearAlgebra.:⋅(x::Vector3, y::Vector3) = x[1]*y[1] + x[2]*y[2] + x[3]*y[3]
 Base.:-(p1::Point3, p2::Point3) = Vector3(p1[1]-p2[1], p1[2]-p2[2], p1[3]-p2[3])
 Base.:+(p1::Point3, p2::Point3) = Vector3(p1[1]+p2[1], p1[2]+p2[2], p1[3]+p2[3])
 LinearAlgebra.:×(x::Vector3, y::Vector3) = Vector3(x[2]*y[3]-x[3]*y[2], -x[1]*y[3]+x[3]*y[1], x[1]*y[2]-x[2]*y[1])
-unitize(v::Vector3) = v/(v⋅v)
+unitize(v::Vector3) = v/sqrt(v⋅v)
 
 #---constants
 #const kTolerance = 1e-9

--- a/src/BoundingBox.jl
+++ b/src/BoundingBox.jl
@@ -26,7 +26,7 @@ inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
 function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
 
     distsurf = Inf
-    (distance, distout) = @inline intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
+    (distance, distout) =  intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
     (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
 end
 

--- a/src/BoundingBox.jl
+++ b/src/BoundingBox.jl
@@ -1,0 +1,75 @@
+
+
+#---Bounding Boxes---------------------------------------------------------------------------------
+# Axis Aligned Bounding Box, defined by the min/max coordinates
+struct AABB{T<:AbstractFloat}
+    min::Point3{T}
+    max::Point3{T}
+end
+
+_area(d) = 2(d[1]*d[2] + d[2]*d[3] + d[3]*d[1])
+_volume(d) = d[1]*d[2]*d[3]
+
+diagonal(bb::AABB{T}) where T = bb.max .- bb.min
+area(bb::AABB{T}) where T = _area(diagonal(bb))
+volume(bb::AABB{T}) where T = _volume(diagonal(bb))
+
+function GeometryBasics.coordinates(bb::AABB{T}) where T
+    a, b = bb.min, bb.max
+    Point3{T}[a, (b[1], a[2], a[3]), (a[1], b[2], a[3]), (a[1], a[2], b[3]),
+                 (a[1], b[2], b[3]), (b[1], a[2], b[3]), (b[1], b[2], a[3]), b]
+end
+GeometryBasics.faces(::AABB{T}) where T = QuadFace{Int64}[(1,3,7,2), (1,2,6,4), (1,4,5,3), (8,6,2,7), (8,7,3,5), (8,5,4,6)]
+GeometryBasics.normals(::AABB{T}) where T = Point3{T}[(0,0,-1), (0,-1,0), (-1,0,0), (1,0,0), (0,1,0), (0,0,1)]
+
+inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
+function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+
+    distsurf = Inf
+    (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
+    (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
+end
+
+#---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
+function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+    
+    tmin = typemin(T)
+    tmax = typemax(T)
+
+    t1v = (bbmin - point) * rcp_dir
+    t2v = (bbmax - point) * rcp_dir
+    
+    # From here on down all we are doing is calculating the following commented lines
+    # Importantly this is non branching and fast without using fastmath 
+    # tmin = maximum(min.(t1v,t2v))
+    # tmax = minimum(max.(t1v,t2v))
+
+    min(x, y) = ifelse(x < y, x, y)
+    max(x, y) = ifelse(x > y, x, y)
+
+
+    for i in 1:3
+        t1 = t1v[i]
+        t2 = t2v[i]
+        flip = t1 > t2
+        tmin = max(ifelse(flip, t2, t1), tmin)
+        tmax = min(ifelse(flip, t1, t2), tmax)
+    end
+    return (tmin,tmax)
+end
+
+function transform_extent(extent::Tuple{Point3{T},Point3}, transformation) where {T}
+    a, b = extent
+    min_ = [ Inf,  Inf,  Inf]
+    max_ = [ -Inf,  -Inf,  -Inf] 
+    coords =  Point3{T}[a, (b[1], a[2], a[3]), (a[1], b[2], a[3]), (a[1], a[2], b[3]),
+                           (a[1], b[2], b[3]), (b[1], a[2], b[3]), (b[1], b[2], a[3]), b]
+    for c in coords
+        p = c * transformation
+        for i in 1:3 
+            p[i] > max_[i] && (max_[i] = p[i])
+            p[i] < min_[i] && (min_[i] = p[i])
+        end
+    end
+    return (Point3{T}(min_), Point3{T}(max_))
+end

--- a/src/BoundingBox.jl
+++ b/src/BoundingBox.jl
@@ -26,7 +26,7 @@ inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
 function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
 
     distsurf = Inf
-    (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
+    (distance, distout) = @inline intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
     (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
 end
 

--- a/src/BoundingBox.jl
+++ b/src/BoundingBox.jl
@@ -30,6 +30,10 @@ function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vect
     (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
 end
 
+function inside(b::AABB{T}, point::Point3{T}) where {T}
+    all(b.min .<= point) && all(b.max .>= point)
+end
+
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
 function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
     

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -69,37 +69,9 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_d
     distsurf = Inf
     max=Point3{T}(box.fDimensions)
     (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
+    ##I have left the distsurf check in this line even though intersectAABoxRay doesn't return it.
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
 end
-# function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
-#     distsurf = Inf
-#     distance = -Inf
-#     distout = Inf
-#     # invdirection = inv.(direction)
-#     for i in 1:3
-#         d=direction[i]
-#         dinv=inv(d)
-#         temp =copysign(box.fDimensions[i],d)
-#         tout =   temp - point[i]
-#         din  = (-temp - point[i])*dinv
-#         dout = tout*dinv
-#         dsur = copysign(tout, d)
-
-#         distance =din > distance  ? din : distance
-#         # if din > distance 
-#         #     distance = din 
-#         # end
-#         distout= dout < distout ? dout : distout
-#         # if dout < distout
-#         #     distout = dout
-#         # end
-#         distsurf = dsur < distsurf ? dsur : distsurf
-#         # if dsur < distsurf
-#         #     distsurf = dsur
-#         # end 
-#     end
-#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
-# end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat
     minimum(box.fDimensions - abs.(point))

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -69,20 +69,28 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T w
     distsurf = Inf
     distance = -Inf
     distout = Inf
+    # invdirection = inv.(direction)
     for i in 1:3
-        din  = (-copysign(box.fDimensions[i],direction[i]) - point[i])/direction[i]
-        tout =   copysign(box.fDimensions[i],direction[i]) - point[i]
-        dout = tout/direction[i]
-        dsur = copysign(tout, direction[i])
-        if din > distance 
-            distance = din 
-        end
-        if dout < distout
-            distout = dout
-        end
-        if dsur < distsurf
-            distsurf = dsur
-        end 
+        d=direction[i]
+        dinv=inv(d)
+        temp =copysign(box.fDimensions[i],d)
+        tout =   temp - point[i]
+        din  = (-temp - point[i])*dinv
+        dout = tout*dinv
+        dsur = copysign(tout, d)
+
+        distance =din > distance  ? din : distance
+        # if din > distance 
+        #     distance = din 
+        # end
+        distout= dout < distout ? dout : distout
+        # if dout < distout
+        #     distout = dout
+        # end
+        distsurf = dsur < distsurf ? dsur : distsurf
+        # if dsur < distsurf
+        #     distsurf = dsur
+        # end 
     end
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
     #invdir = 1.0 ./ direction

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -65,42 +65,41 @@ function distanceToOut(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T 
     #safety > kTolerance(T)/2 ? -1.0 : distance
 end
 
-function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
+function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_direction::Vector3{T}=inv.(direction))::T where T<:AbstractFloat
     distsurf = Inf
-    distance = -Inf
-    distout = Inf
-    # invdirection = inv.(direction)
-    for i in 1:3
-        d=direction[i]
-        dinv=inv(d)
-        temp =copysign(box.fDimensions[i],d)
-        tout =   temp - point[i]
-        din  = (-temp - point[i])*dinv
-        dout = tout*dinv
-        dsur = copysign(tout, d)
-
-        distance =din > distance  ? din : distance
-        # if din > distance 
-        #     distance = din 
-        # end
-        distout= dout < distout ? dout : distout
-        # if dout < distout
-        #     distout = dout
-        # end
-        distsurf = dsur < distsurf ? dsur : distsurf
-        # if dsur < distsurf
-        #     distsurf = dsur
-        # end 
-    end
+    max=Point3{T}(box.fDimensions)
+    (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
-    #invdir = 1.0 ./ direction
-    #tempIn  = -copysign.(box.fDimensions, direction) - point
-    #tempOut =  copysign.(box.fDimensions, direction) - point
-    #distance = maximum(tempIn * invdir)
-    #distout  = minimum(tempOut * invdir)
-    #distsurf = abs(minimum(copysign.(tempOut, direction)))
-    #(distance >= distout || distout <= kTolerance(T)/2 || distsurf <= kTolerance(T)/2) ? Inf : distance
 end
+# function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T where T<:AbstractFloat
+#     distsurf = Inf
+#     distance = -Inf
+#     distout = Inf
+#     # invdirection = inv.(direction)
+#     for i in 1:3
+#         d=direction[i]
+#         dinv=inv(d)
+#         temp =copysign(box.fDimensions[i],d)
+#         tout =   temp - point[i]
+#         din  = (-temp - point[i])*dinv
+#         dout = tout*dinv
+#         dsur = copysign(tout, d)
+
+#         distance =din > distance  ? din : distance
+#         # if din > distance 
+#         #     distance = din 
+#         # end
+#         distout= dout < distout ? dout : distout
+#         # if dout < distout
+#         #     distout = dout
+#         # end
+#         distsurf = dsur < distsurf ? dsur : distsurf
+#         # if dsur < distsurf
+#         #     distsurf = dsur
+#         # end 
+#     end
+#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
+# end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat
     minimum(box.fDimensions - abs.(point))

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -70,7 +70,7 @@ function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_d
     max=Point3{T}(box.fDimensions)
     (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
     ##I have left the distsurf check in this line even though intersectAABoxRay doesn't return it.
-    (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
+    (distance >= distout || isnan(distance) || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
 end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -66,11 +66,16 @@ function distanceToOut(box::Box{T}, point::Point3{T}, direction::Vector3{T})::T 
 end
 
 function distanceToIn(box::Box{T}, point::Point3{T}, direction::Vector3{T},rcp_direction::Vector3{T}=inv.(direction))::T where T<:AbstractFloat
-    distsurf = Inf
+    
     max=Point3{T}(box.fDimensions)
     (distance,distout)= intersectAABoxRay(-max,max,point,direction,rcp_direction)
-    ##I have left the distsurf check in this line even though intersectAABoxRay doesn't return it.
-    (distance >= distout || isnan(distance) || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? Inf : distance
+    
+    # The checks are as follows:
+    # 1.) distance < -kTolerance(T) would mean that we are already further in the volume than a micro step
+    # 2.) distance >= distout Not sure if this is still needed
+    # 3.) isnan(distance) NaN use to escape the intersect intersection routine and would cause problems
+    # 4.) distout <= kTolerance(T)/2) Checks to see if we are entering and immediatelly exiting
+    (distance < -kTolerance(T) || distance >= distout || isnan(distance) || distout <= kTolerance(T)/2) ? Inf : distance
 end
 
 function safetyToOut(box::Box{T}, point::Point3{T}) where T<:AbstractFloat

--- a/src/Geom4hep.jl
+++ b/src/Geom4hep.jl
@@ -20,6 +20,7 @@ using StaticArrays, GeometryBasics, LinearAlgebra, Rotations, AbstractTrees
 include("BasicTypes.jl")
 include("Transformation3D.jl")
 include("TriangleIntersect.jl")
+include("BoundingBox.jl")
 include("Trd.jl")
 include("Box.jl")
 include("Wedge.jl")

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -120,74 +120,14 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector
     (distance,distout)= intersectAABoxRay(bb.min,bb.max,point,dir,rcp_dir)
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end
-# function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-#     point = point - (bb.max + bb.min)/2
-#     dimens = (bb.max - bb.min)/2
-#     distsurf = Inf
-#     distance = -Inf
-#     distout = Inf
-#     for i in 1:3
-#         d=dir[i]
-#         invd=rcp_dir[i]
-#         signeddim = copysign(dimens[i],d) 
-#         din  = (-signeddim - point[i])*invd
-#         tout =   signeddim - point[i]
-#         dout = tout*invd
-#         dsur = copysign(tout, d)
-#         distance =din > distance  ? din : distance
-#         distout= dout < distout ? dout : distout
-#         distsurf = dsur < distsurf ? dsur : distsurf
-#     end
-#     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
-# end
 
-
-# function intersectAABBRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-#     tmin=typemin(T)
-#     tmax=typemax(T)
-#     for i in 1:3
-#         invd=rcp_dir[i]
-#         p=point[i]
-#         t1 = (bbmin[i]-p)*invd
-#         t2 = (bbmax[i]-p)*invd
-#         tmin=min(max(t1,tmin),max(t2,tmin))
-#         tmax=max(min(t1,tmax),min(t2,tmax))
-#     end
-#     (tmin,tmax) 
-# end
-
-
-# function intersectAABBRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-
-
-#     t1v=(bbmin-point)*rcp_dir
-#     t2v=(bbmax-point)*rcp_dir
-#     # From here on down all we are doing is calculating the following commented lines
-#     # tmin = maximum(min.(t1v,t2v))
-#     # tmax = minimum(max.(t1v,t2v))
-
-#     t1 = t1v[1]
-#     t2 = t2v[1]
-#     flip = t1 > t2
-#     tmin =ifelse(flip,t2,t1)
-#     tmax =ifelse(flip,t1,t2)
-#     for i in 2:3 
-#         t1 = t1v[i]
-#         t2 = t2v[i]
-#         flip = t1 > t2
-#         t1 =ifelse(flip,t2,t1)
-#         t2 =ifelse(flip,t1,t2)
-#         tmin = ifelse(t1>tmin,t1,tmin)
-#         tmax = ifelse(t2<tmax,t2,tmax)
-#     end
-#     (tmin,tmax)
-# end
 function intersectAABoxRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
 
 
     t1v=(bbmin-point)*rcp_dir
     t2v=(bbmax-point)*rcp_dir
     # From here on down all we are doing is calculating the following commented lines
+    # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
     # tmax = minimum(max.(t1v,t2v))
 

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -118,7 +118,7 @@ function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vect
 
     distsurf = Inf
     (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
-    (distance >= distout || isnan(distance) || distout <= kTolerance(T) / 2 || abs(distsurf) <= kTolerance(T) / 2) ? false : true
+    (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
 end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
@@ -129,7 +129,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
 
     t1v = (bbmin - point) * rcp_dir
     t2v = (bbmax - point) * rcp_dir
-
+    
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
@@ -138,6 +138,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
     min(x, y) = ifelse(x < y, x, y)
     max(x, y) = ifelse(x > y, x, y)
 
+
     for i in 1:3
         t1 = t1v[i]
         t2 = t2v[i]
@@ -145,7 +146,7 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
         tmin = max(ifelse(flip, t2, t1), tmin)
         tmax = min(ifelse(flip, t1, t2), tmax)
     end
-
+    return (tmin,tmax)
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -121,34 +121,33 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end
 
-function intersectAABoxRay(bbmin::Point3{T},bbmax::Point3{T},point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-
-
-    t1v=(bbmin-point)*rcp_dir
-    t2v=(bbmax-point)*rcp_dir
+#---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
+function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+    t1v = (bbmin - point) * rcp_dir
+    t2v = (bbmax - point) * rcp_dir
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
     # tmax = minimum(max.(t1v,t2v))
 
-    min(x,y) = ifelse(x < y , x, y)
-    max(x,y) = ifelse(x > y , x, y)
+    min(x, y) = ifelse(x < y, x, y)
+    max(x, y) = ifelse(x > y, x, y)
 
     t1 = t1v[1]
     t2 = t2v[1]
     flip = t1 > t2
-    tmin =ifelse(flip,t2,t1)
-    tmax =ifelse(flip,t1,t2)
-    for i in 2:3 
+    tmin = ifelse(flip, t2, t1)
+    tmax = ifelse(flip, t1, t2)
+    for i in 2:3
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
-        t1 =ifelse(flip,t2,t1)
-        t2 =ifelse(flip,t1,t2)
-        tmin = max(t1,tmin)
-        tmax = min(t2,tmax)
+        t1 = ifelse(flip, t2, t1)
+        t2 = ifelse(flip, t1, t2)
+        tmin = max(t1, tmin)
+        tmax = min(t2, tmax)
     end
-    (tmin,tmax)
+    (tmin, tmax)
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -123,8 +123,13 @@ end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
 function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+    
+    tmin = typemin(T)
+    tmax = typemax(T)
+
     t1v = (bbmin - point) * rcp_dir
     t2v = (bbmax - point) * rcp_dir
+
     # From here on down all we are doing is calculating the following commented lines
     # Importantly this is non branching and fast without using fastmath 
     # tmin = maximum(min.(t1v,t2v))
@@ -133,19 +138,14 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
     min(x, y) = ifelse(x < y, x, y)
     max(x, y) = ifelse(x > y, x, y)
 
-    t1 = t1v[1]
-    t2 = t2v[1]
-    flip = t1 > t2
-    tmin = ifelse(flip, t2, t1)
-    tmax = ifelse(flip, t1, t2)
-    for i in 2:3
+    for i in 1:3
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
         tmin = max(ifelse(flip, t2, t1), tmin)
         tmax = min(ifelse(flip, t1, t2), tmax)
     end
-    (tmin, tmax)
+
 end
 
 function AABB(pvol::PlacedVolume{T}) where T

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -3,7 +3,7 @@ const Shape{T<:AbstractFloat} = Union{BaseShape{T},
                                       BooleanUnion{T}, 
                                       BooleanSubtraction{T}, 
                                       BooleanIntersection{T}}
-
+# const Shape{T<:AbstractFloat} = AbstractShape{T}
 #---Volume-------------------------------------------------------------------------
 struct VolumeP{T<:AbstractFloat,PV}
     id::Int64
@@ -91,80 +91,10 @@ function getWorld(vol::Volume{T}) where T<:AbstractFloat
     end
 end
 
-#---Bounding Boxes---------------------------------------------------------------------------------
-# Axis Aligned Bounding Box, defined by the min/max coordinates
-struct AABB{T<:AbstractFloat}
-    min::Point3{T}
-    max::Point3{T}
-end
-
-_area(d) = 2(d[1]*d[2] + d[2]*d[3] + d[3]*d[1])
-_volume(d) = d[1]*d[2]*d[3]
-
-diagonal(bb::AABB{T}) where T = bb.max .- bb.min
-area(bb::AABB{T}) where T = _area(diagonal(bb))
-volume(bb::AABB{T}) where T = _volume(diagonal(bb))
-
-function GeometryBasics.coordinates(bb::AABB{T}) where T
-    a, b = bb.min, bb.max
-    Point3{T}[a, (b[1], a[2], a[3]), (a[1], b[2], a[3]), (a[1], a[2], b[3]),
-                 (a[1], b[2], b[3]), (b[1], a[2], b[3]), (b[1], b[2], a[3]), b]
-end
-GeometryBasics.faces(::AABB{T}) where T = QuadFace{Int64}[(1,3,7,2), (1,2,6,4), (1,4,5,3), (8,6,2,7), (8,7,3,5), (8,5,4,6)]
-GeometryBasics.normals(::AABB{T}) where T = Point3{T}[(0,0,-1), (0,-1,0), (-1,0,0), (1,0,0), (0,1,0), (0,0,1)]
-
-inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
-function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
-
-    distsurf = Inf
-    (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
-    (distance >= distout  || distout <= kTolerance(T) / 2 ) ? false : true
-end
-
-#---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
-function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
-    
-    tmin = typemin(T)
-    tmax = typemax(T)
-
-    t1v = (bbmin - point) * rcp_dir
-    t2v = (bbmax - point) * rcp_dir
-    
-    # From here on down all we are doing is calculating the following commented lines
-    # Importantly this is non branching and fast without using fastmath 
-    # tmin = maximum(min.(t1v,t2v))
-    # tmax = minimum(max.(t1v,t2v))
-
-    min(x, y) = ifelse(x < y, x, y)
-    max(x, y) = ifelse(x > y, x, y)
-
-
-    for i in 1:3
-        t1 = t1v[i]
-        t2 = t2v[i]
-        flip = t1 > t2
-        tmin = max(ifelse(flip, t2, t1), tmin)
-        tmax = min(ifelse(flip, t1, t2), tmax)
-    end
-    return (tmin,tmax)
-end
 
 function AABB(pvol::PlacedVolume{T}) where T
-    a, b = extent(pvol.volume.shape)
-    min_ = [ Inf,  Inf,  Inf]
-    max_ = [ -Inf,  -Inf,  -Inf] 
-    coords =  Point3{T}[a, (b[1], a[2], a[3]), (a[1], b[2], a[3]), (a[1], a[2], b[3]),
-                           (a[1], b[2], b[3]), (b[1], a[2], b[3]), (b[1], b[2], a[3]), b]
-    for c in coords
-        p = c * pvol.transformation
-        for i in 1:3 
-            p[i] > max_[i] && (max_[i] = p[i])
-            p[i] < min_[i] && (min_[i] = p[i])
-        end
-    end
-    return AABB{T}(Point3{T}(min_), Point3{T}(max_))
+    AABB{T}(transform_extent(extent(pvol.volume.shape),pvol.transformation)...)
 end
-
 
 #---Assemblies--------------------------------------------------------------------------------------
 struct Assembly{T<:AbstractFloat}

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -114,11 +114,11 @@ GeometryBasics.faces(::AABB{T}) where T = QuadFace{Int64}[(1,3,7,2), (1,2,6,4), 
 GeometryBasics.normals(::AABB{T}) where T = Point3{T}[(0,0,-1), (0,-1,0), (-1,0,0), (1,0,0), (0,1,0), (0,0,1)]
 
 inside(bb::AABB{T}, point::Point3{T}) where T =  all(bb.min .< point .< bb.max)
-function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T},rcp_dir::Vector3{T}=inv.(dir)) where T
-    
+function intersect(bb::AABB{T}, point::Point3{T}, dir::Vector3{T}, rcp_dir::Vector3{T}=inv.(dir)) where {T}
+
     distsurf = Inf
-    (distance,distout)= intersectAABoxRay(bb.min,bb.max,point,dir,rcp_dir)
-    (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
+    (distance, distout) = intersectAABoxRay(bb.min, bb.max, point, dir, rcp_dir)
+    (distance >= distout || isnan(distance) || distout <= kTolerance(T) / 2 || abs(distsurf) <= kTolerance(T) / 2) ? false : true
 end
 
 #---Fast Axial Aligned Bounded Box Ray intersection routine.  Returns both distances to the intesections
@@ -142,10 +142,8 @@ function intersectAABoxRay(bbmin::Point3{T}, bbmax::Point3{T}, point::Point3{T},
         t1 = t1v[i]
         t2 = t2v[i]
         flip = t1 > t2
-        t1 = ifelse(flip, t2, t1)
-        t2 = ifelse(flip, t1, t2)
-        tmin = max(t1, tmin)
-        tmax = min(t2, tmax)
+        tmin = max(ifelse(flip, t2, t1), tmin)
+        tmax = min(ifelse(flip, t1, t2), tmax)
     end
     (tmin, tmax)
 end

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -152,8 +152,19 @@ function surface(agg::Aggregate{T}) where T<:AbstractFloat
 end
 
 function extent(agg::Aggregate{T})::Tuple{Point3{T},Point3{T}} where T<:AbstractFloat
-    return (min((extent(pvol.volume.shape)[1] * pvol.transformation  for pvol in agg.pvolumes)...),
-            max((extent(pvol.volume.shape)[2] * pvol.transformation  for pvol in agg.pvolumes)...))
+    tm=typemax(T)
+    mmin = Point3{T}(tm,tm,tm)
+
+    tm=typemin(T)
+    mmax = Point3{T}(tm,tm,tm)
+    for pvol in agg.pvolumes
+        pmin = pvol.aabb.min
+        pmax = pvol.aabb.max
+        mmin = min.(mmin,pmin)
+        mmax = min.(max,pmax)
+    end
+
+    return (mmin,mmax)
 end
 
 function inside(agg::Aggregate{T}, point::Point3{T})::Int64  where T<:AbstractFloat

--- a/src/Volume.jl
+++ b/src/Volume.jl
@@ -121,19 +121,25 @@ function intersect(bb::AABB{T}, point::Point3{T},dir::Vector3{T}) where T
     distance = -Inf
     distout = Inf
     for i in 1:3
-        din  = (-copysign(dimens[i],dir[i]) - point[i])/dir[i]
-        tout =   copysign(dimens[i],dir[i]) - point[i]
-        dout = tout/dir[i]
-        dsur = copysign(tout, dir[i])
-        if din > distance 
-            distance = din 
-        end
-        if dout < distout
-            distout = dout
-        end
-        if dsur < distsurf
-            distsurf = dsur
-        end 
+        d=dir[i]
+        invd=inv(d)
+        signeddim = copysign(dimens[i],dir[i]) 
+        din  = (-signeddim - point[i])*invd
+        tout =   signeddim - point[i]
+        dout = tout*invd
+        dsur = copysign(tout, d)
+        distance =din > distance  ? din : distance
+        distout= dout < distout ? dout : distout
+        distsurf = dsur < distsurf ? dsur : distsurf
+        # if din > distance 
+        #     distance = din 
+        # end
+        # if dout < distout
+        #     distout = dout
+        # end
+        # if dsur < distsurf
+        #     distsurf = dsur
+        # end 
     end
     (distance >= distout || distout <= kTolerance(T)/2 || abs(distsurf) <= kTolerance(T)/2) ? false : true
 end


### PR DESCRIPTION
Overall from master, this brings the xray benchmark from 2.2s -> 1.4 on my computer.  

1. First in the process of doing this, I found a bug in the extant calculations for booleans & and aggregates fixing it caused a 25% regression on my machine 2s->2.5s because there were more intersections in the BVH for the booleans.   Numerically the calculation is just as efficient.   It stole the code for extent of a placed volume and made it into a function.  This refresion was worth 25%
2. I added an AABB and intersection check to PlacedVolume this makes the multiple dispatch(even though I don't think this is the problem) not happen most time.    This saves around 25%.
3. Add AABB for both the left and right objects in booleans.   Then we use those bounding boxes to shortcut the calculation of `distanceToIn` `distanceToOut` and `inside` .   This simplifies the evaluation of most booleans because most of the time the evaluation is for only one of the shapes.   This also saves 25%.
4.  Moved AABB and the bounding box stuff to its own file to be used earlier.

The boolean multiple dispatch is not a problem anymore.   When you profile the code it doesn't even show up anymore.  
I think what is still an issue and I will make an issue on Monday is that the ray tracing is O(~n^2) where n is the number of shapes intersected.   The worst pixels on the benchmark goes through 800 shapes(381 mean), but distanceToIn is called 69,000 times 
